### PR TITLE
Add support for GNOME 47 to metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,8 @@
   "uuid": "legacyschemeautoswitcher@joshimukul29.gmail.com",
   "shell-version": [
     "45",
-    "46"
+    "46",
+    "47"
   ],
   "version": 1
 }


### PR DESCRIPTION
Working on GNOME 47, no changes required